### PR TITLE
Fix image layout

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -466,6 +466,16 @@ a:hover {
     color: var(--primary-color);
 }
 
+/* Ensure post images scale and are centered */
+.post-image {
+    display: block;
+    margin: 1.5rem auto;
+    max-width: 100%;
+    height: auto;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    border-radius: 8px;
+}
+
 p > code {
     background: rgba(88, 93, 193, 0.15);
     color: var(--accent-color);

--- a/jekyll/_posts/2025-07-30-keeping-claude-code-costs-in-check.md
+++ b/jekyll/_posts/2025-07-30-keeping-claude-code-costs-in-check.md
@@ -11,7 +11,7 @@ Claude Code usage isn’t free, and keeping costs under control matters—for se
 
 I care about both. So, to stay mindful of my Claude Code spend, I built a small macOS app that puts the current usage right in the menu bar:
 
-![claude-nein](/img/claude-nein.png)
+![claude-nein](/img/claude-nein.png){: .post-image }
 
 It’s called [Claude Nein](https://github.com/forketyfork/claude-nein) — a pun on “cloud nine.”
 


### PR DESCRIPTION
## Summary
- keep post images responsive with `post-image` class
- use the new class on the Claude Nein screenshot

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688a4992a6f48332a9940e92389ee360