### PR TITLE
Fix Giscus custom CSS accessibility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,6 @@
 import '../css/style.css';
 import '../css/custom.css';
 import '../css/fruity.css';
-import '../css/giscus-custom.css';
 
 // Showing a CRT-style cursor instead of the mouse pointer
 document.addEventListener('DOMContentLoaded', function () {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,9 +1,17 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: 'css/giscus-custom.css', to: 'css/giscus-custom.css' },
+      ],
+    }),
+  ],
   devServer: {
     liveReload: true,
     hot: true,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -24,6 +24,7 @@ module.exports = merge(common, {
         { from: 'js/vendor', to: 'js/vendor' },
         { from: 'favicon.ico', to: 'favicon.ico' },
         { from: 'icon.png', to: 'icon.png' },
+        { from: 'css/giscus-custom.css', to: 'css/giscus-custom.css' },
       ],
     }),
   ],


### PR DESCRIPTION
Remove giscus-custom.css from app.js imports to prevent bundling and add explicit copy patterns to webpack configs to ensure the CSS file is accessible at /css/giscus-custom.css URL. This allows Giscus to reference the theme file directly as required.