### PR TITLE
Split GitHub workflows into separate build and publish actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build Jekyll site
+
+on:
+  push:
+    branches: ["*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Cache Nix store
+        uses: cachix/cachix-action@v16
+        with:
+          name: forketyfork
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Webpack build
+        run: |
+          nix develop --command bash -c '
+            yarn install || { echo "Yarn install failed"; exit 1; }
+            yarn build || { echo "Webpack build failed"; exit 1; }
+          '
+
+      - name: Build Jekyll site with Nix
+        run: |
+          nix develop --command bash -c '
+            bundle install || { echo "Bundle install failed"; exit 1; }
+            bundle exec jekyll build --source jekyll || { echo "Jekyll build failed"; exit 1; }
+          '
+        env:
+          JEKYLL_ENV: production

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,9 @@ jobs:
           '
         env:
           JEKYLL_ENV: production
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jekyll-build
+          path: jekyll/_site/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,15 @@ jobs:
             yarn build || { echo "Webpack build failed"; exit 1; }
           '
 
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Build Jekyll site with Nix
         run: |
           nix develop --command bash -c '
             bundle install || { echo "Bundle install failed"; exit 1; }
-            bundle exec jekyll build --source jekyll || { echo "Jekyll build failed"; exit 1; }
+            bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --source jekyll || { echo "Jekyll build failed"; exit 1; }
           '
         env:
           JEKYLL_ENV: production

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Jekyll site
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,10 @@
 name: Publish Jekyll site to Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build Jekyll site"]
+    types:
+      - completed
     branches: ["main"]
   workflow_dispatch:
 
@@ -15,53 +18,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Cache Nix store
-        uses: cachix/cachix-action@v16
-        with:
-          name: forketyfork
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Webpack build
-        run: |
-          nix develop --command bash -c '
-            yarn install || { echo "Yarn install failed"; exit 1; }
-            yarn build || { echo "Webpack build failed"; exit 1; }
-          '
+          name: jekyll-build
+          path: _site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
 
-      - name: Build Jekyll site with Nix
-        run: |
-          nix develop --command bash -c '
-            bundle install || { echo "Bundle install failed"; exit 1; }
-            bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --source jekyll || { echo "Jekyll build failed"; exit 1; }
-          '
-        env:
-          JEKYLL_ENV: production
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
 
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: publish
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to Pages
+name: Publish Jekyll site to Pages
 
 on:
   push:


### PR DESCRIPTION
- Create build.yml: runs on all branch pushes for CI validation
- Create publish.yml: runs on main branch merges for deployment
- Remove original jekyll.yml workflow
- Improves CI efficiency by separating build validation from deployment