### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/forketyfork.github.io/security/code-scanning/1](https://github.com/forketyfork/forketyfork.github.io/security/code-scanning/1)

The best way to fix the problem is by adding an explicit `permissions` block to restrict the GITHUB_TOKEN permissions for the workflow or the specific job. Since the workflow appears to perform build steps and uploads artifacts, but does not push to the repository, interact with issues, or modify pull requests, the minimal needed permission is likely `contents: read`. 

This change should be added either at the root level (applies to all jobs) or directly under the `build` job (applies only to that job). In this case, for clarity and least privilege, adding it at the job level (to `build:`) suffices and is a minimally invasive change.

No additional methods, imports, or definitions are necessary—just the addition of the `permissions:` block with `contents: read` in the YAML file under the `build` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
