### PR TITLE
Fix Jekyll artifact upload path in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jekyll-build
-          path: jekyll/_site/
+          path: _site/


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions build workflow by correcting the artifact upload path.

## Problem
The build workflow was failing to upload the jekyll-build artifact because:
- Jekyll outputs to  in the working directory root  
- But the upload-artifact step was looking for  which doesn't exist

This caused the publish workflow to fail with "Artifact not found for name: jekyll-build".

## Solution
Changed the artifact upload path from  to  to match Jekyll's actual output directory.

## Test Results
✅ Build workflow now completes successfully  
✅ jekyll-build artifact is properly created  
✅ Publish workflow should now be able to find and use the artifact

Fixes the publication pipeline for GitHub Pages deployment.