### PR TITLE
build: fingerprint CSS and JS bundles to bust stale caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 _site/
 .jekyll-cache/
 jekyll/dist/
+jekyll/_data/manifest.json
 .direnv
 .DS_Store
 .playwright-mcp/

--- a/jekyll/_layouts/default.html
+++ b/jekyll/_layouts/default.html
@@ -4,7 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="{{ '/css/style.css' | relative_url }}">
+    {%- assign css_href = site.data.manifest['style.css'] | default: '/css/style.css' -%}
+    <link rel="stylesheet" href="{{ css_href | relative_url }}">
 
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="apple-touch-icon" href="/icon.png">
@@ -83,7 +84,8 @@
         </footer>
     </div>
 
-    <script src="{{ 'js/app.js' | relative_url }}"></script>
+    {%- assign js_src = site.data.manifest['app.js'] | default: '/js/app.js' -%}
+    <script src="{{ js_src | relative_url }}"></script>
 
 </body>
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,11 +1,41 @@
+const path = require('path');
+const fs = require('fs');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
+// Emit jekyll/_data/manifest.json mapping logical asset names to their
+// content-hashed output files. Jekyll reads it as site.data.manifest and links
+// the fingerprinted URLs, so a content change produces a new URL and the CDN /
+// browser cache can no longer serve a stale bundle.
+class JekyllManifestPlugin {
+  apply(compiler) {
+    compiler.hooks.done.tap('JekyllManifestPlugin', (stats) => {
+      const manifest = {};
+      Object.keys(stats.compilation.assets).forEach((name) => {
+        if (name.startsWith('js/app.') && name.endsWith('.js')) {
+          manifest['app.js'] = '/' + name;
+        } else if (name.startsWith('css/style.') && name.endsWith('.css')) {
+          manifest['style.css'] = '/' + name;
+        }
+      });
+      const dataDir = path.resolve(__dirname, 'jekyll', '_data');
+      fs.mkdirSync(dataDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dataDir, 'manifest.json'),
+        JSON.stringify(manifest, null, 2) + '\n'
+      );
+    });
+  }
+}
+
 module.exports = merge(common, {
   mode: 'production',
+  output: {
+    filename: 'js/app.[contenthash].js',
+  },
   module: {
     rules: [
       {
@@ -16,7 +46,7 @@ module.exports = merge(common, {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: 'css/style.css',
+      filename: 'css/style.[contenthash].css',
     }),
     new CopyPlugin({
       patterns: [
@@ -27,6 +57,7 @@ module.exports = merge(common, {
         { from: 'css/giscus-custom.css', to: 'css/giscus-custom.css' },
       ],
     }),
+    new JekyllManifestPlugin(),
   ],
   optimization: {
     minimizer: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -12,15 +12,31 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 // browser cache can no longer serve a stale bundle.
 class JekyllManifestPlugin {
   apply(compiler) {
-    compiler.hooks.done.tap('JekyllManifestPlugin', (stats) => {
+    compiler.hooks.afterEmit.tap('JekyllManifestPlugin', (compilation) => {
+      // Don't overwrite a good manifest when the build has failed.
+      if (compilation.errors.length) return;
+
+      // Take the files straight from the app entrypoint so we only ever pick
+      // up its own hashed bundles, not copied assets (vendor, giscus, etc.).
+      const entrypoint = compilation.entrypoints.get('app');
+      const files = entrypoint ? entrypoint.getFiles() : [];
       const manifest = {};
-      Object.keys(stats.compilation.assets).forEach((name) => {
-        if (name.startsWith('js/app.') && name.endsWith('.js')) {
-          manifest['app.js'] = '/' + name;
-        } else if (name.startsWith('css/style.') && name.endsWith('.css')) {
-          manifest['style.css'] = '/' + name;
-        }
+      files.forEach((name) => {
+        if (name.endsWith('.js')) manifest['app.js'] = '/' + name;
+        else if (name.endsWith('.css')) manifest['style.css'] = '/' + name;
       });
+
+      // Fail the build rather than emit a manifest the layout can't resolve.
+      if (!manifest['app.js'] || !manifest['style.css']) {
+        compilation.errors.push(
+          new Error(
+            'JekyllManifestPlugin: expected hashed JS and CSS in the "app" entrypoint, found ' +
+              JSON.stringify(files)
+          )
+        );
+        return;
+      }
+
       const dataDir = path.resolve(__dirname, 'jekyll', '_data');
       fs.mkdirSync(dataDir, { recursive: true });
       fs.writeFileSync(


### PR DESCRIPTION
## Summary

After a deploy, the updated CSS often didn't apply until a full refresh. The cause: GitHub Pages serves assets with `Cache-Control: max-age=600`, and the bundles had stable names (`/css/style.css`, `/js/app.js`). With the filename unchanged, the browser and the Fastly edge kept serving the cached copy for up to ten minutes.

This fingerprints the bundles. Webpack now emits `css/style.[contenthash].css` and `js/app.[contenthash].js`, and a small inline plugin writes `jekyll/_data/manifest.json` mapping the logical names to the hashed files. The layout links them through `site.data.manifest` (with a fallback to the unhashed names). A content change produces a new URL the cache can't satisfy, so the new CSS shows up immediately; unchanged content keeps its hash, so a deploy doesn't force a needless re-download.

The manifest is a build artifact (gitignored) and is regenerated by `yarn build`, which already runs before `jekyll build` in CI.

## Test plan

- [ ] Run `yarn build` and confirm `jekyll/_data/manifest.json` lists hashed `style.*.css` / `app.*.js`, and that `jekyll/dist/css` and `jekyll/dist/js` contain those files.
- [ ] Build the site and confirm the rendered `<link>`/`<script>` in the HTML point at the hashed filenames (not `/css/style.css`).
- [ ] Make a real CSS change, rebuild, and confirm the hash (and the referenced URL) changes; revert it and confirm the hash returns to its previous value.
- [ ] After this is deployed, change something visible in the CSS in a later deploy and confirm it applies without a hard refresh.
