### PR TITLE
Add 7-day Dependabot cooldown for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,22 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
-      all-actions:
+      all-dependencies:
         patterns:
           - "*"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
-      all-actions:
+      all-dependencies:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
Add a 7-day cooldown to every Dependabot update block so new dependency versions settle for a week before an update PR is opened.

Also rename the npm and bundler groups from `all-actions` to `all-dependencies` to match the naming used across the other repos.